### PR TITLE
:bug: fix operator<

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 project("bosswestfalen::runtime_array"
-        VERSION 0.6.0
+        VERSION 0.6.1
         LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/include/bosswestfalen/runtime_array.hpp
+++ b/include/bosswestfalen/runtime_array.hpp
@@ -1,7 +1,7 @@
 /*!
  * \file runtime_array.hpp
  * \author Bosswestfalen (https://github.com/Bosswestfalen)
- * \version 0.6.0
+ * \version 0.6.1
  * \date 2019
  * \copyright MIT License
  */
@@ -414,11 +414,6 @@ template <typename T>
 bool operator<(runtime_array<T> const& lhs, runtime_array<T> const& rhs)
 //noexcept(noexcept(T{} == T{}) and noexcept(T{} != T{}) and noexcept(T{} < T{}))
 {
-    if (lhs.size() < rhs.size())
-    {
-        return true;
-    }
-
     return std::lexicographical_compare(lhs.cbegin(), lhs.cend(), rhs.cbegin(), rhs.cend());
 }
 

--- a/unit-test/test-compare.cpp
+++ b/unit-test/test-compare.cpp
@@ -43,11 +43,16 @@ TEST_CASE("compare", "[compare]")
 
     SECTION("less")
     {
+        auto const c = test_array{4};
+
         REQUIRE_FALSE(empty < empty);
         REQUIRE_FALSE(a < a);
+        REQUIRE_FALSE(a < b);
+        REQUIRE_FALSE(c < a);
 
         REQUIRE(empty < a);
-        REQUIRE(a < b);
+        REQUIRE(b < a);
+        REQUIRE(a < c);
     }
 }
 


### PR DESCRIPTION
Assumed smaller arrays are always less -> {1} < {0, 1} was trueA
Not < uses compares correctly